### PR TITLE
Update README.md to use hilla extension instead of vaadin

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then you can run the main method of `Application.java`.
 
 ## Deploying to Production
 
-To create a production build, call `gradlew -Pvaadin.productionMode=true build` (Windows), or `./gradlew -Pvaadin.productionMode=true build` (Mac & Linux).
+To create a production build, call `gradlew -Philla.productionMode=true build` (Windows), or `./gradlew -Philla.productionMode=true build` (Mac & Linux).
 This will build a JAR file with all the dependencies and front-end resources, ready to be deployed.
 The file can be found in the `build/libs/` folder after the build completes.
 


### PR DESCRIPTION
## Description

The hilla extension allows gradle users to use
`-Philla.productionMode=true` instead of `-Pvaadin.productionMode=true`.
